### PR TITLE
refactor: Switch to ES modules for server application

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,9 +1,9 @@
-import {useEffect, useState} from "react";
+import { useEffect, useState } from "react";
 const API_URL = process.env.REACT_APP_API;
 
 function App() {
   const [data, setData] = useState("No data :(");
-  
+
   useEffect(() => {
     async function getData() {
       const url = `${API_URL}/hello`;
@@ -12,7 +12,7 @@ function App() {
       setData(data.msg);
     }
     getData();
-  }, []); 
+  }, []);
 
   return (
     <>

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,10 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
+import React from "react";
+import ReactDOM from "react-dom";
+import App from "./App";
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root')
+  document.getElementById("root")
 );

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,7 @@
 {
   "name": "node-api-server",
   "version": "1.0.0",
+  "type": "module",
   "main": "server.js",
   "scripts": {
     "start": "node src/index.js"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,5 +1,7 @@
-const appName = "Server API"; 
+import createServer from "./server.js";
+
+const appName = "Server API";
 const port = process.env.PORT || 8080;
-const createServer = require("./server");
 const server = createServer();
+
 server.listen(port, () => console.log(`${appName} running on port ${port}!`));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -3,7 +3,7 @@ import express from "express";
 function createRouter() {
   const router = express.Router();
 
-  /* Routes */
+  /* Define all routes */
   router.get("/hello", async (req, res) => {
     res.json({ msg: "Hello, world!" });
   });

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -1,15 +1,18 @@
-module.exports = () => {
-  const express = require("express");
+import express from "express";
+
+function createRouter() {
   const router = express.Router();
 
-  /**** Routes ****/
-  router.get('/hello', async (req, res) => {
-    res.json({msg: "Hello, world!"});
+  /* Routes */
+  router.get("/hello", async (req, res) => {
+    res.json({ msg: "Hello, world!" });
   });
 
-  router.get('/hello/:name', async (req, res) => {
-    res.json({msg: `Hello, ${req.params.name}`});
+  router.get("/hello/:name", async (req, res) => {
+    res.json({ msg: `Hello, ${req.params.name}` });
   });
 
   return router;
 }
+
+export default createRouter;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,33 +1,33 @@
-/**** Node.js libraries *****/
-const path = require('path');
+/* Node.js libraries */
+import path from "path";
 
-/**** External libraries ****/
-const express = require('express'); 
-const bodyParser = require('body-parser');
-const morgan = require('morgan');
-const cors = require('cors');
+/* External libraries */
+import express from "express";
+import bodyParser from "body-parser";
+import morgan from "morgan";
+import cors from "cors";
 
-/**** Configuration ****/
-const app = express(); 
+/* Local files */
+import createRouter from "./routes.js";
 
 function createServer() {
-  const routes = require("./routes")();
+  const app = express();
 
-  app.use(bodyParser.json()); 
+  app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
-  app.use(morgan('combined')); 
+  app.use(morgan("combined"));
   app.use(cors());
-  app.use(express.static(path.resolve('..', 'client', 'build'))); 
-  
-  /**** Add routes ****/
-  app.use("/api", routes);
+  app.use(express.static(path.resolve("..", "client", "build")));
+
+  /* Add routes */
+  app.use("/api", createRouter());
 
   // "Redirect" all non-API GET requests to React's entry point (index.html)
-  app.get('*', (req, res) =>
-    res.sendFile(path.resolve('..', 'client', 'build', 'index.html'))
+  app.get("*", (req, res) =>
+    res.sendFile(path.resolve("..", "client", "build", "index.html"))
   );
-  
+
   return app;
 }
 
-module.exports = createServer;
+export default createServer;

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -12,16 +12,33 @@ import createRouter from "./routes.js";
 function createServer() {
   const app = express();
 
+  /* The express.json() middleware automatically parses JSON data in the body of
+   * requests: http://expressjs.com/en/api.html#express.json */
   app.use(express.json());
+
+  /* The express.urlencoded() middleware automatically parses urlencoded payloads
+   * into the req.body property:
+   * http://expressjs.com/en/api.html#express.urlencoded */
   app.use(express.urlencoded({ extended: false }));
+
+  /* The morgan() middleware logs request info to the console while the server is
+   * running: https://expressjs.com/en/resources/middleware/morgan.html */
   app.use(morgan("combined"));
+
+  /* The cors() middleware allows Cross-Origin Resource Sharing when developing
+   * locally: http://expressjs.com/en/resources/middleware/cors.html */
   app.use(cors());
+
+  /* The express.static() middleware serves our static files from the pre-built
+   * React app: http://expressjs.com/en/api.html#express.static */
   app.use(express.static(path.resolve("..", "client", "build")));
 
-  /* Add routes */
+  /* We add our own routes as middleware on the `/api` path */
   app.use("/api", createRouter());
 
-  // "Redirect" all non-API GET requests to React's entry point (index.html)
+  /* "Redirect" all non-API GET requests to React's entry point (index.html)
+   * which allows the React SPA's client side navigation library to handle full
+   * page refreshes */
   app.get("*", (req, res) =>
     res.sendFile(path.resolve("..", "client", "build", "index.html"))
   );

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -3,7 +3,6 @@ import path from "path";
 
 /* External libraries */
 import express from "express";
-import bodyParser from "body-parser";
 import morgan from "morgan";
 import cors from "cors";
 
@@ -13,8 +12,8 @@ import createRouter from "./routes.js";
 function createServer() {
   const app = express();
 
-  app.use(bodyParser.json());
-  app.use(bodyParser.urlencoded({ extended: false }));
+  app.use(express.json());
+  app.use(express.urlencoded({ extended: false }));
   app.use(morgan("combined"));
   app.use(cors());
   app.use(express.static(path.resolve("..", "client", "build")));


### PR DESCRIPTION
Adds `"type": "module"` to the server app's `package.json` and exchanges all usages of `require` to `import`. 

It is far easier to navigate when the `server` and `client` apps use the same module system.

Also adds some comments to document the middleware used.